### PR TITLE
[Hotfix] Local Mute Flag

### DIFF
--- a/agorauikit_android/src/main/java/io/agora/agorauikit_android/AgoraVideoViewer+Buttons.kt
+++ b/agorauikit_android/src/main/java/io/agora/agorauikit_android/AgoraVideoViewer+Buttons.kt
@@ -62,6 +62,7 @@ internal fun AgoraVideoViewer.getMicButton(): AgoraButton? {
     agMicButton.clickAction = {
         it.isSelected = !it.isSelected
         it.background.setTint(if (it.isSelected) Color.RED else Color.GRAY)
+        this.userVideoLookup[this.userID]?.audioMuted = it.isSelected
         this.agkit.muteLocalAudioStream(it.isSelected)
     }
     this.micButton = agMicButton


### PR DESCRIPTION
Changing the local audio state with mutelocalaudiostream is not triggering onLocalAudioStateChanged anymore.
Updated to add the muted flag in the button action instead.